### PR TITLE
feat: Add mining icon to the calcified rocks

### DIFF
--- a/src/main/java/com/cwjoshuak/CamTorumMiningConfig.java
+++ b/src/main/java/com/cwjoshuak/CamTorumMiningConfig.java
@@ -4,7 +4,6 @@ import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-import net.runelite.client.util.ColorUtil;
 
 import java.awt.*;
 
@@ -52,7 +51,8 @@ public interface CamTorumMiningConfig extends Config
 		name = "Notify Water Spawn",
 		description = "Notifies you when watery rocks spawn"
 	)
-	default boolean notifyWater() {
+	default boolean notifyWater()
+	{
 		return true;
 	}
 
@@ -62,7 +62,19 @@ public interface CamTorumMiningConfig extends Config
 		name = "Dynamically swap depleted rock menu entries",
 		description = "Swap menu entries to only make calcified rocks clickable."
 	)
-	default boolean dynamicMenuEntrySwap() {
+	default boolean dynamicMenuEntrySwap()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 6,
+			keyName = "showVeins",
+			name = "Show calcified mining spots",
+			description = "Configures whether or not the calcified mining spots are displayed."
+	)
+	default boolean showVeins()
+	{
 		return true;
 	}
 }

--- a/src/main/java/com/cwjoshuak/CamTorumMiningConfig.java
+++ b/src/main/java/com/cwjoshuak/CamTorumMiningConfig.java
@@ -68,10 +68,10 @@ public interface CamTorumMiningConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 6,
-			keyName = "showVeins",
-			name = "Show calcified mining spots",
-			description = "Configures whether or not the calcified mining spots are displayed."
+		position = 6,
+		keyName = "showVeins",
+		name = "Show calcified mining spots",
+		description = "Configures whether or not the calcified mining spots are displayed."
 	)
 	default boolean showVeins()
 	{

--- a/src/main/java/com/cwjoshuak/CamTorumMiningOverlay.java
+++ b/src/main/java/com/cwjoshuak/CamTorumMiningOverlay.java
@@ -39,6 +39,11 @@ public class CamTorumMiningOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		if (!plugin.isInCamTorumMiningArea())
+		{
+			return null;
+		}
+
 		Player player = client.getLocalPlayer();
 
 		renderStreams(graphics, player);

--- a/src/main/java/com/cwjoshuak/CamTorumMiningOverlay.java
+++ b/src/main/java/com/cwjoshuak/CamTorumMiningOverlay.java
@@ -1,51 +1,111 @@
 package com.cwjoshuak;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import net.runelite.api.*;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.util.ColorUtil;
 
-public class CamTorumMiningOverlay extends Overlay {
+public class CamTorumMiningOverlay extends Overlay
+{
+	private static final int MAX_DISTANCE = 2350;
 
 	private final CamTorumMiningConfig config;
 	private final CamTorumMiningPlugin plugin;
 	private final Client client;
 
+	private final BufferedImage miningIcon;
+
 	@Inject
-	private CamTorumMiningOverlay(Client client, CamTorumMiningConfig config, CamTorumMiningPlugin plugin)
+	private CamTorumMiningOverlay(Client client, CamTorumMiningConfig config, CamTorumMiningPlugin plugin, SkillIconManager iconManager)
 	{
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.ABOVE_SCENE);
+
 		this.config = config;
 		this.plugin = plugin;
 		this.client = client;
-		setPosition(OverlayPosition.DYNAMIC);
-		setLayer(OverlayLayer.ABOVE_SCENE);
+
+		miningIcon = iconManager.getSkillImage(Skill.MINING);
 	}
 
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		Player player = client.getLocalPlayer();
+
+		renderStreams(graphics, player);
+		renderVeins(graphics, player);
+		return null;
+	}
+
+	private void renderStreams(Graphics2D graphics, Player player)
+	{
 		if (plugin.getStreams().isEmpty())
 		{
-			return null;
+			return;
 		}
-		Player player = client.getLocalPlayer();
-		plugin.getStreams().forEach((object, tile) ->
-		{
-			if (tile.getWorldLocation().distanceTo(player.getWorldLocation()) < config.maxDistance()) {
 
-				Shape objectClickbox = object.getClickbox();
-				if (objectClickbox != null) {
-					graphics.setColor(config.getWaterOutlineColor());
-					graphics.draw(objectClickbox);
-					Color waterFillColor = config.getWaterFillColor();
-					graphics.setColor(ColorUtil.colorWithAlpha(waterFillColor, waterFillColor.getAlpha() / 12));
-					graphics.fill(objectClickbox);
-				}
+		WorldPoint playerLocation = player.getWorldLocation();
+		for (TileObject stream : plugin.getStreams())
+		{
+			WorldPoint location = stream.getWorldLocation();
+			if (playerLocation.distanceTo(location) >= config.maxDistance())
+			{
+				// Stream is outside the requested distance, do not render
+				continue;
 			}
-		});
-		return null;
+
+			Shape objectClickbox = stream.getClickbox();
+			if (objectClickbox == null)
+			{
+				continue;
+			}
+
+			// Draw border
+			Color outsideColor = config.getWaterOutlineColor();
+			graphics.setColor(outsideColor);
+			graphics.draw(objectClickbox);
+
+			// Draw inside
+			Color waterFillColor = config.getWaterFillColor();
+			Color insideColor = ColorUtil.colorWithAlpha(waterFillColor, waterFillColor.getAlpha() / 12);
+			graphics.setColor(insideColor);
+			graphics.fill(objectClickbox);
+		}
+	}
+
+	private void renderVeins(Graphics2D graphics, Player player)
+	{
+		if (!config.showVeins() || plugin.getVeins().isEmpty())
+		{
+			return;
+		}
+
+		LocalPoint playerLocation = player.getLocalLocation();
+		for (TileObject vein : plugin.getVeins())
+		{
+			Point canvasLocation = Perspective.getCanvasImageLocation(client, vein.getLocalLocation(), miningIcon, 150);
+			if (canvasLocation == null)
+			{
+				continue;
+			}
+
+			LocalPoint location = vein.getLocalLocation();
+			if (playerLocation.distanceTo(location) >= MAX_DISTANCE)
+			{
+				// Vein is too far away for the player to see, do not render an icon
+				continue;
+			}
+
+			graphics.drawImage(miningIcon, canvasLocation.getX(), canvasLocation.getY(), null);
+		}
 	}
 }

--- a/src/main/java/com/cwjoshuak/CamTorumMiningPlugin.java
+++ b/src/main/java/com/cwjoshuak/CamTorumMiningPlugin.java
@@ -192,7 +192,14 @@ public class CamTorumMiningPlugin extends Plugin
 			return;
 		}
 
-		boolean alreadyMiningStream = false;
+		if (!isAlreadyMiningStream())
+		{
+			notifier.notify("Watery rocks spawned!");
+		}
+	}
+
+	private boolean isAlreadyMiningStream()
+	{
 		Player player = client.getLocalPlayer();
 		WorldPoint playerLocation = player.getWorldLocation();
 
@@ -215,15 +222,10 @@ public class CamTorumMiningPlugin extends Plugin
 			if (player.getAnimation() >= 0)
 			{
 				// Assuming they are performing a mining animation if it isn't -1
-				alreadyMiningStream = true;
-				break;
+				return true;
 			}
 		}
-
-		if (!alreadyMiningStream)
-		{
-			notifier.notify("Watery rocks spawned!");
-		}
+		return false;
 	}
 
 	private boolean isPlayerMiningNotifiedRock()


### PR DESCRIPTION
The calcified rocks are dark and thus can be difficult to see.
As I'm afking at work, just like mother load mine, icons can be very helpful.
Thus I added mining icons.
There is a max distance configured, which is used from the mother load plugin.

![image](https://github.com/user-attachments/assets/b80b0226-00d2-4551-9cb3-d893d25a21a1)
![image](https://github.com/user-attachments/assets/bf21434c-2f0f-4b0e-9ad1-74edd3fe0f3f)

While developing this feature, I noticed you're using a HashMap which wasn't necessary.
The object already contains the tile location.
I also notified a big inconsistency in the use of braces.
Since I had to refactor the code anyway I also extracted it to a separate function.

I changed both in the same PR (which I know is not desired) as it may be easier for you to review a single PR.
I can separate them in two PR's if requested.